### PR TITLE
Fix for broken option in SbS to use existing MAD-X file (-x 1)

### DIFF
--- a/SegmentBySegment/SegmentBySegment.py
+++ b/SegmentBySegment/SegmentBySegment.py
@@ -70,7 +70,7 @@ import Utilities.iotools
 import json
 from Python_Classes4MAD.metaclass import twiss
 from Utilities import bpm
-from madx import madx_templates_runner
+from madx import madx_templates_runner, madx_wrapper
 
 import numpy
 
@@ -221,7 +221,7 @@ def main(options):
         else:
             print "Just rerunning mad"
             mad_file_path, log_file_path = _get_files_for_mad(save_path, element_name)
-            _runmad(mad_file_path, log_file_path, options.mad)
+            madx_wrapper.resolve_and_run_file(mad_file_path, log_file=log_file_path)            
 
         reversetable(save_path, element_name)
 


### PR DESCRIPTION
I just noticed that Segment-by-Segment does not work anymore if the option "-x 1" is used.
This option should prevent to (re-)create the madx file, and just use the one in the output directory.
It is helpful to have this option, if one would like to manually test modifications in the madx script.