### PR TITLE
only import matplotlib if needed

### DIFF
--- a/Utilities/twiss_to_tbt.py
+++ b/Utilities/twiss_to_tbt.py
@@ -4,7 +4,6 @@ import numpy as np
 import __init__
 import tfs_pandas as tfs
 import pandas as pd
-import matplotlib.pyplot as plt
 
 C = 299792458.0 
 PI2 = np.pi * 2
@@ -49,6 +48,7 @@ def generate(infile, nturns=6600, plane ='X',       #single plane with no coupli
     return signal
 
 def plot_bpm_tbt(path, signal, num):
+    import matplotlib.pyplot as plt
     f,ax = plt.subplots()
     ax.plot(signal[num])
     f.savefig(os.path.join(path, str(num) +'.png'))


### PR DESCRIPTION
Remove strict matplotlib/pyplot dependency from twiss_to_tbt.py, as this breaks the online coupling tool.

The import can be done in the function in case it is called (it is not in the coupling analysis, and probably neither in other automated analyses). Adding matplotlib to the docker image would be quite a pain as it comes with a lot of dependencies (X11, Qt, GUI stuff etc).