### PR TITLE
Enhancement/#134/madx wrapper logging

### DIFF
--- a/global_correct_iterative.py
+++ b/global_correct_iterative.py
@@ -919,11 +919,7 @@ def _create_corrected_model(twiss_out, change_params, accel_inst, debug):
     madx_script = accel_inst.get_update_correction_job(twiss_out, change_params)
     # run madx
     if debug:
-        with logging_tools.TempFile("correct_iter_madxout.tmp", LOG.debug) as log_file:
-            madx_wrapper.resolve_and_run_string(
-                madx_script,
-                log_file=log_file,
-            )
+        madx_wrapper.resolve_and_run_string(madx_script)
     else:
         madx_wrapper.resolve_and_run_string(
             madx_script,

--- a/madx_wrapper.py
+++ b/madx_wrapper.py
@@ -94,11 +94,10 @@ def _run(full_madx_script, log_file=None, output_file=None, madx_path=MADX_PATH,
     """ Starts the madx-process """
     with _madx_input_wrapper(full_madx_script, output_file) as madx_jobfile:
         process = subprocess.Popen([madx_path, madx_jobfile], shell=False,
-                                   stdin=subprocess.PIPE,
                                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd)
-    with _logfile_wrapper(log_file) as log_handler, process.stdout:
-        for line in iter(process.stdout.readline, b''):
-            log_handler(line)
+        with _logfile_wrapper(log_file) as log_handler, process.stdout:
+            for line in iter(process.stdout.readline, b''):
+                log_handler(line)
         status = process.wait()
 
     if status:

--- a/madx_wrapper.py
+++ b/madx_wrapper.py
@@ -15,6 +15,9 @@ import optparse
 import contextlib
 from tempfile import mkstemp
 
+from utils import logging_tools
+LOG = logging_tools.get_logger(__name__)
+
 LIB = abspath(join(dirname(__file__), "madx", "lib"))
 if "darwin" in sys.platform:
     MADX_PATH = abspath(join(dirname(__file__), "madx", "bin", "madx-macosx64-intel"))
@@ -89,10 +92,13 @@ def resolve_and_run_string(input_string, output_file=None, log_file=None,
 
 def _run(full_madx_script, log_file=None, output_file=None, madx_path=MADX_PATH, cwd=None):
     """ Starts the madx-process """
-    with _logfile_wrapper(log_file) as log_output, _madx_input_wrapper(full_madx_script, output_file) as madx_jobfile:
+    with _madx_input_wrapper(full_madx_script, output_file) as madx_jobfile:
         process = subprocess.Popen([madx_path, madx_jobfile], shell=False,
                                    stdin=subprocess.PIPE,
-                                   stdout=log_output, stderr=log_output, cwd=cwd)
+                                   stdout=subprocess.PIPE, stderr=subprocess.STDOUT, cwd=cwd)
+    with _logfile_wrapper(log_file) as log_handler, process.stdout:
+        for line in iter(process.stdout.readline, b''):
+            log_handler(line)
         status = process.wait()
 
     if status:
@@ -150,12 +156,21 @@ def _check_log_and_output_files(output_file, log_file):
 
 @contextlib.contextmanager
 def _logfile_wrapper(file_path=None):
-    """ Returns opened file stream to file_path if given or stdout """
+    """ Logs into file and debug if file is given, into info otherwise """
     if file_path is None:
-        yield sys.stdout
+        def log_handler(line):
+            line = line.rstrip()
+            if len(line):
+                LOG.info(line)
+        yield log_handler
     else:
         with open(file_path, "w") as log_file:
-            yield log_file
+            def log_handler(line):
+                log_file.write(line)
+                line = line.rstrip()
+                if len(line):
+                    LOG.debug(line)
+            yield log_handler
 
 
 @contextlib.contextmanager

--- a/utils/iotools.py
+++ b/utils/iotools.py
@@ -78,6 +78,8 @@ def copy_item(src_item, dest):
             shutil.copy2(src_item, dest)
         elif os.path.isdir(src_item):
             copy_content_of_dir(src_item, dest)
+        else:
+            raise IOError
     except IOError:
         LOG.error("Could not copy item because of IOError. Item: '{}'".format(src_item))
 


### PR DESCRIPTION
Fixes #134.
Enables continous logging when running madx from wrapper. 
If a logfile is given it loggs to this file and debug.
If no logfile is given it loggs to info.

Hint: to deactivate output, set logger to info (standard level, i.e. do nothing) and set logfile to os.devnull.