### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ PyYAML>=3.12
 ipython>=5.5.0
 attrs>=19.2.0
 cmmnbuild-dep-manager<2.3
+JPype1>=0.6.2,<0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,10 @@ six>=1.11.0
 Sphinx>=1.7.5
 sphinx-rtd-theme>=0.2.4
 travis-sphinx>=2.1.0
-pytimber>=2.6.2
 pytz>=2018.4
 PyYAML>=3.12
 ipython>=5.5.0
 attrs>=19.2.0
 cmmnbuild-dep-manager<2.3
 JPype1>=0.6.2,<0.7.0
+pytimber>=2.6.2,<3.0.0


### PR DESCRIPTION
Fixes #204

pip install was failing because of pytimber
requiring a library only supporting python3