### PR TITLE
Fix beta from amp NaN values

### DIFF
--- a/GetLLM/algorithms/beta.py
+++ b/GetLLM/algorithms/beta.py
@@ -160,6 +160,10 @@ def _write_getbeta_out(twiss_d_zero_dpp, q1, q2, mad_ac, number_of_bpms, range_o
                             row[4], row[5], row[6], row[7],
                             mod_BET[model_ac_index], mod_ALF[model_ac_index], mod_MU[model_ac_index],
                             row[10]]
+
+        if beta_d_col[name][0] < 0:  # BETX or BETY
+            print_('Warning: beta value for {} is negative: {}'.format(name, beta_d_col[name][0]))
+
         # list_row_entries = ['"' + name + '"', mad_ac.S[model_ac_index], len(twiss_d_zero_dpp),
         #                     row[0], row[1], row[2], row[3],
         #                     row[8],

--- a/GetLLM/algorithms/get_action.py
+++ b/GetLLM/algorithms/get_action.py
@@ -133,12 +133,23 @@ def get_kick_from_bpm_list_w_ACdipole_phase(amp, beta_phase,beta_phase_error):
     amplitude is obtained from Drive/SUSSIX and is normalized with the model beta-function.
 
     '''
-    beta_phase_filter = np.array(beta_phase)[(np.array(beta_phase) > -1)]
+
+    # Remove the negative beta phase values, which can be here for some reason
+    indices = [i for i, e in enumerate(beta_phase) if e < 0]
+    beta_phase = np.delete(beta_phase, indices)
+    beta_phase_error = np.delete(beta_phase_error, indices)
+
+    new_amp = []
+    for i in range(len(amp)):
+        new_amp.append(np.delete(amp[i], indices))
+    amp = np.asarray(new_amp)
+
     actions = (((amp).transpose() * (1/(beta_phase.transpose()**0.5))[:, np.newaxis]).mean(0))**2
     actions_error_spread = ((amp).transpose() * (1/(beta_phase.transpose()**0.5))[:, np.newaxis]).std(0)
     actions_error_std = (actions_error_spread/len(amp[0])**0.5)
     actions_error_phase = ((((amp**2).transpose() * 1/(beta_phase.transpose()**2)[:, np.newaxis] * beta_phase_error.transpose()[:, np.newaxis])**2).sum(0))**0.5/len(amp[0])
-    return actions,actions_error_spread,actions_error_std,actions_error_phase
+    
+    return actions, actions_error_spread, actions_error_std, actions_error_phase
 
 
 def get_kick_from_bpm_list_w_ACdipole_model(amp, beta_model):


### PR DESCRIPTION
Beta from amplitude is calculated via the action, which uses a square root of the beta from phase.
This can't be calculated if some beta from phase values are negative.

This commit removes the negative values and carries on with the action calculation.
The action value should not be impacted as it's roughly an average over all the BPMs.
A warning is added during the beta from phase calculation if a value is negative.
