### PR TITLE
add paths to old and new main seqs

### DIFF
--- a/model/accelerators/lhc.py
+++ b/model/accelerators/lhc.py
@@ -1050,10 +1050,11 @@ class HlLhc13(LhcAts):
 
 
 def _get_call_main_for_year(year):
-    if year < 2021:
+    # create possible acc-models name if it doesn't exist, assume that we have an old model
+    file_for_year = os.path.join(ACC_MODELS_DIR, year, "lhc.seq")
+    if not os.path.exists(file_for_year):
         file_for_year = _get_file_for_year(year, "main.seq")
-    else:
-        file_for_year = os.path.join(ACC_MODELS_DIR, year, "lhc.seq")
+
     call_main = _get_madx_call_command(file_for_year)
     return call_main
 

--- a/model/model_creators/lhc_model_creator.py
+++ b/model/model_creators/lhc_model_creator.py
@@ -115,8 +115,7 @@ class LhcModelCreator(model_creator.ModelCreator):
             "CROSSING_ON": crossing_on,
         }
 
-        with open(os.path.join(output_path,
-                               "job.iterate.madx"), "w") as textfile:
+        with open(os.path.join(output_path, "job.iterate.madx"), "w") as textfile:
             textfile.write(iterate_template % replace_dict)
 
 


### PR DESCRIPTION
checks for LHC if model tag exists in acc-models
if not, assumes that it's an old model and gets main sequence from BetaBeat.src