### PR TITLE
coupling and tune knobs for 2022

### DIFF
--- a/correction/fullresponse/LHCB1/AllLists_couple.json
+++ b/correction/fullresponse/LHCB1/AllLists_couple.json
@@ -1,5 +1,5 @@
 {
-  "coupling_knobs_squeeze": [
+  "coupling_knobs": [
       "CMIS.b1_op",
       "CMRS.b1_op"
   ], 

--- a/correction/fullresponse/LHCB1/AllLists_couple.json
+++ b/correction/fullresponse/LHCB1/AllLists_couple.json
@@ -1,9 +1,5 @@
 {
   "coupling_knobs": [
-      "CMIS.b1_op",
-      "CMRS.b1_op"
-  ], 
-  "coupling_knobs_old": [
     "b1_re_ip7_knob",  
     "b1_im_ip7_knob"
   ], 

--- a/correction/fullresponse/LHCB2/AllLists_couple.json
+++ b/correction/fullresponse/LHCB2/AllLists_couple.json
@@ -1,9 +1,5 @@
 {
   "coupling_knobs": [
-    "CMIS.b2_op",  
-    "CMRS.b2_op"
-  ], 
-  "coupling_knobs_old": [
     "b2_re_ip7_knob",  
     "b2_im_ip7_knob"
   ], 

--- a/correction/fullresponse/LHCB2/AllLists_couple.json
+++ b/correction/fullresponse/LHCB2/AllLists_couple.json
@@ -1,5 +1,5 @@
 {
-  "coupling_knobs_squeeze": [
+  "coupling_knobs": [
     "CMIS.b2_op",  
     "CMRS.b2_op"
   ], 

--- a/madx/lib/lhc_runIII_2022.macros.madx
+++ b/madx/lib/lhc_runIII_2022.macros.madx
@@ -15,23 +15,10 @@ load_main_sequence(): macro = {
 };
 
 coupling_knob(beam_number): macro = {
-    if (ARC_SQUEEZE == 1.0){
-    /*This correct but the knob was not implemented by in LSA 
-        Cmrs.b1_sq := b1_re_ip7_knob;
-        Cmrs.b2_sq := b2_re_ip7_knob;
-        Cmis.b1_sq := b1_im_ip7_knob;
-        Cmis.b2_sq := b2_im_ip7_knob;
-        */
-        Cmrs.b1 := b1_re_ip7_knob;
-        Cmrs.b2 := b2_re_ip7_knob;
-        Cmis.b1 := b1_im_ip7_knob;
-        Cmis.b2 := b2_im_ip7_knob;
-    } else {
-        Cmrs.b1 := b1_re_ip7_knob;
-        Cmrs.b2 := b2_re_ip7_knob;
-        Cmis.b1 := b1_im_ip7_knob;
-        Cmis.b2 := b2_im_ip7_knob;
-    }
+    Cmrs.b1_op := b1_re_ip7_knob;
+    Cmrs.b2_op := b2_re_ip7_knob;
+    Cmis.b1_op := b1_im_ip7_knob;
+    Cmis.b2_op := b2_im_ip7_knob;
 };
 
 

--- a/madx/lib/lhc_runIII_2022.macros.madx
+++ b/madx/lib/lhc_runIII_2022.macros.madx
@@ -15,10 +15,11 @@ load_main_sequence(): macro = {
 };
 
 coupling_knob(beam_number): macro = {
-    Cmrs.b1_op := b1_re_ip7_knob;
-    Cmrs.b2_op := b2_re_ip7_knob;
-    Cmis.b1_op := b1_im_ip7_knob;
-    Cmis.b2_op := b2_im_ip7_knob;
+    CMRS.b1 := b1_re_ip7_knob;
+    CMIS.b1 := b1_im_ip7_knob;
+
+    CMRS.b2 := b2_re_ip7_knob;
+    CMIS.b2 := b2_im_ip7_knob;
 };
 
 

--- a/madx/lib/lhc_runIII_2022.macros.madx
+++ b/madx/lib/lhc_runIII_2022.macros.madx
@@ -13,3 +13,53 @@ load_main_sequence(): macro = {
     system, "ln -s /afs/cern.ch/eng/acc-models/lhc/2022/ acc-models-lhc";
     call, file = "/afs/cern.ch/eng/acc-models/lhc/2022/lhc.seq";
 };
+
+coupling_knob(beam_number): macro = {
+    if (ARC_SQUEEZE == 1.0){
+    /*This correct but the knob was not implemented by in LSA 
+        Cmrs.b1_sq := b1_re_ip7_knob;
+        Cmrs.b2_sq := b2_re_ip7_knob;
+        Cmis.b1_sq := b1_im_ip7_knob;
+        Cmis.b2_sq := b2_im_ip7_knob;
+        */
+        Cmrs.b1 := b1_re_ip7_knob;
+        Cmrs.b2 := b2_re_ip7_knob;
+        Cmis.b1 := b1_im_ip7_knob;
+        Cmis.b2 := b2_im_ip7_knob;
+    } else {
+        Cmrs.b1 := b1_re_ip7_knob;
+        Cmrs.b2 := b2_re_ip7_knob;
+        Cmis.b1 := b1_im_ip7_knob;
+        Cmis.b2 := b2_im_ip7_knob;
+    }
+};
+
+
+/*
+* Performs the matching of the LHC tunes, adapted to ATS optics.
+* uses op knobs
+*/
+match_tunes(nqx, nqy, beam_number): macro = {
+    exec, find_complete_tunes(nqx, nqy, beam_number);
+    exec, match_tunes_op(total_qx, total_qy, beam_number);
+};
+
+
+match_tunes_op(nqx, nqy, beam_number): macro = {
+    match;
+    vary, name=dQx.bbeam_number_op;
+    vary, name=dQy.bbeam_number_op;
+    constraint, range=#E, mux=nqx, muy=nqy;
+    lmdif;
+    endmatch;
+};
+
+
+match_tunes_arc_squeeze(nqx, nqy, beam_number): macro = {
+    match;
+    vary, name=dQx.bbeam_number_sq;
+    vary, name=dQy.bbeam_number_sq;
+    constraint, range=#E, mux=nqx, muy=nqy;
+    lmdif;
+    endmatch;
+};

--- a/model/accelerators/lhc.py
+++ b/model/accelerators/lhc.py
@@ -977,6 +977,8 @@ class LhcRunII2018(LhcAts):
 
 class LhcRunIII2022(LhcAts):
     YEAR = "2022"
+    MACROS_NAME = "lhc_runIII_2022"
+
 
 
 class HlLhc10(LhcAts):


### PR DESCRIPTION
This pull request finalises the 2022 model creation changes concerning coupling and tune knobs for commissioning.

- `_op` knobs are now used for coupling and tune
- `_sq` knobs are kept, just in case